### PR TITLE
fix: use total expo instead of notional for volume.

### DIFF
--- a/projects/SMARDEX-USDN/index.js
+++ b/projects/SMARDEX-USDN/index.js
@@ -7,7 +7,7 @@ const REBALANCER_ADDRESS = "0xaebcc85a5594e687f6b302405e6e92d616826e03";
 async function fetchUSDNData(api) {
 
   const balanceVault = await api.call({ target: USDN_PROTOCOL_ADDRESS, abi: "uint256:getBalanceVault", });
-  const balanceLong = await api.call({ target: USDN_PROTOCOL_ADDRESS, abi: "uint256:getBalanceLong", });
+  const totalExpo = await api.call({ target: USDN_PROTOCOL_ADDRESS, abi: "uint256:getTotalExpo", });
   const rebalancerCurrentStateData = await api.call({
     target: REBALANCER_ADDRESS,
     abi: "function getCurrentStateData() view returns (uint128 pendingAssets_, uint256 maxLeverage_, (int24 tick, uint256 tickVersion, uint256 index) currentPosId_)",
@@ -15,7 +15,7 @@ async function fetchUSDNData(api) {
 
   return {
     getBalanceVault: balanceVault,
-    getBalanceLong: balanceLong,
+    getTotalExpo: totalExpo,
     rebalancerPendingAssets: rebalancerCurrentStateData.pendingAssets_,
   };
 }


### PR DESCRIPTION
Fix the USDN volume that was invalid until now. The old volume were computed on the notional size of positions while the other perp dex platforms are computing the volume on the total exposition of the positions (leverage of the position is counted). The volume computation is now consistant with the other platforms.
It might be needed to refresh your data from the block [21673602](https://etherscan.io/block/21673602) (Jan-21-2025 02:56:59 PM +UTC) until now after merging.Fix the USDN volume that was invalid until now. The old volume were computed on the notional size of positions while the other perp dex platforms are computing the volume on the total exposition of the positions (leverage of the position is counted). The volume computation is now consistant with the other platforms.
It might be needed to refresh your data from the block [21673602](https://etherscan.io/block/21673602) (Jan-21-2025 02:56:59 PM +UTC) until now after merging.